### PR TITLE
fix for nested shebang

### DIFF
--- a/execv.c
+++ b/execv.c
@@ -102,7 +102,7 @@ int ie_execve(const char* path, char* const argv[], char* const envp[]) {
     }
     argv_new[offset + argcount + 1] = NULL;
 
-    int ret = execve(argv_new[0], argv_new, envp);
+    int ret = ie_execve(argv_new[0], argv_new, envp);
     free(freeme);
     return ret;
 }


### PR DESCRIPTION
before
```
iPhone101:~ mobile% cat a
#!/bin/bash
echo $#
iPhone101:~ mobile% cat b
#!./a abc
iPhone101:~ mobile% ./b
zsh: operation not permitted: ./b
iPhone101:~ mobile%
```

after
```
iPhone101:~ mobile% cat a
#!/bin/bash
echo $#
iPhone101:~ mobile% cat b
#!./a abc
iPhone101:~ mobile% ./b
2
iPhone101:~ mobile%
```