### PR TITLE
Use the wildcard function (& other changes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LN       ?= ln
 RANLIB   ?= ranlib
 INSTALL  ?= install
 
+MEMO_PREFIX     ?=
 MEMO_SUB_PREFIX ?= /usr
 LIBDIR          ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
 INCLUDEDIR      ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,9 @@ LN       ?= ln
 RANLIB   ?= ranlib
 INSTALL  ?= install
 
-MEMO_PREFIX     ?=
-MEMO_SUB_PREFIX ?= /usr
-LIBDIR          ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
-INCLUDEDIR      ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include
+PREFIX     ?= /usr
+LIBDIR     ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
 
 SOVER := 1
 SRC   := $(wildcard *.c)

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ LIBDIR          ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
 INCLUDEDIR      ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include
 
 SOVER := 1
-
-SRC := execl.c execv.c utils.c get_new_argv.c posix_spawn.c
+SRC   := $(wildcard *.c)
 
 all: libiosexec.$(SOVER).dylib libiosexec.a
 

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ libiosexec.a: $(SRC:%.c=%.o)
 	$(RANLIB) $@
 
 test: libiosexec.a
-	$(CC) $(CFLAGS) -I. tests/test.c -o tests/test $(LDFLAGS) ./libiosexec.a
-	cd tests && ./test
+	$(CC) $(CFLAGS) -I. tests/test.c -o tests/test $(LDFLAGS) $^
+	./tests/test
 
 install: all
 	$(INSTALL) -Dm644 libiosexec.$(SOVER).dylib $(DESTDIR)$(LIBDIR)/libiosexec.$(SOVER).dylib
@@ -34,6 +34,6 @@ install: all
 	$(INSTALL) -Dm644 libiosexec.h $(DESTDIR)$(INCLUDEDIR)/libiosexec.h
 
 clean:
-	rm -f libiosexec.$(SOVER).dylib libiosexec.a *.o ./tests/test
+	rm -f libiosexec.$(SOVER).dylib libiosexec.a *.o tests/test
 
 .PHONY: all clean install

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ LN       ?= ln
 RANLIB   ?= ranlib
 INSTALL  ?= install
 
-PREFIX     ?= /usr
-LIBDIR     ?= $(PREFIX)/lib
-INCLUDEDIR ?= $(PREFIX)/include
+MEMO_SUB_PREFIX ?= /usr
+LIBDIR          ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
+INCLUDEDIR      ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include
 
 SOVER := 1
 SRC   := $(wildcard *.c)
@@ -25,7 +25,7 @@ libiosexec.a: $(SRC:%.c=%.o)
 
 test: libiosexec.a
 	$(CC) $(CFLAGS) -I. tests/test.c -o tests/test $(LDFLAGS) $^
-	./tests/test
+	cd tests && ./test
 
 install: all
 	$(INSTALL) -Dm644 libiosexec.$(SOVER).dylib $(DESTDIR)$(LIBDIR)/libiosexec.$(SOVER).dylib


### PR DESCRIPTION
This PR changes the variable, `SRC`, to use the wildcard function. Small changes were made to several Makefile rules, and the prefix variable was shortened to only use one variable.