### PR TITLE
correct newargv[1]

### DIFF
--- a/get_new_argv.c
+++ b/get_new_argv.c
@@ -98,7 +98,9 @@ get_new_argv(const char *path, char *const argv[])
 
 	newargv = realloc(interpargv, (interpc + argc + 1) * sizeof(char *));
 	newargv[interpc + argc] = NULL;
-	for (int i = 0; i < argc; i++) {
+	/* i = 1 to avoid old argv[0] being passed to interpreter */
+        newargv[interpc] = strdup(path);
+	for (int i = 1; i < argc; i++) {
 		newargv[interpc + i] = strdup(argv[i]);
 	}
 


### PR DESCRIPTION
fixes a bug happens with cfae759

by adding prints, we can see an unexpected argv has been passed to interp.
```
iPad:/buildroot/gcc-12.2.0/build/test root# cat Makefile 
all:
        makeinfo --help
iPad:/buildroot/gcc-12.2.0/build/test root# make                                                                                                                                                                                                    
makeinfo --help
ie_posix_spawn: called
ie_posix_spawn: argv[0] = makeinfo
ie_posix_spawn: argv[1] = --help
get_new_argv: called: path = /usr/bin/makeinfo
get_new_argv: argv[0] = makeinfo
get_new_argv: argv[1] = --help
get_new_argv: interpc = 1
get_new_argv: argc = 2
get_new_argv: newargv[0] = /usr/bin/perl
get_new_argv: newargv[1] = makeinfo
get_new_argv: newargv[2] = --help
ie_posix_spawn: new_args[0] = /usr/bin/perl
ie_posix_spawn: new_args[1] = makeinfo
ie_posix_spawn: new_args[2] = --help
Can't open perl script "makeinfo": No such file or directory
make: *** [Makefile:2: all] Error 2
```

This corrects the behavior of setting new_args by forcing new_args[1] to be the `path` that being passed to `get_new_argv`
```
iPad:/buildroot/gcc-12.2.0/build/test root# make                                                                                                                                                                                                    
makeinfo --help
ie_posix_spawn: called
ie_posix_spawn: argv[0] = makeinfo
ie_posix_spawn: argv[1] = --help
get_new_argv: called: path = /usr/bin/makeinfo
get_new_argv: argv[0] = makeinfo
get_new_argv: argv[1] = --help
get_new_argv: interpc = 1
get_new_argv: argc = 2
get_new_argv: newargv[0] = /usr/bin/perl
get_new_argv: newargv[1] = /usr/bin/makeinfo
get_new_argv: newargv[2] = --help
ie_posix_spawn: new_args[0] = /usr/bin/perl
ie_posix_spawn: new_args[1] = /usr/bin/makeinfo
ie_posix_spawn: new_args[2] = --help
用法：makeinfo [选项]... TEXINFO-文件...
```