### PR TITLE
Migrate to Node16-based Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,16 @@ name: Build
 on:
   push:
     paths-ignore:
-      - 'LICENSE'  
-      - '**/*.md'  
+      - 'LICENSE'
+      - '**/*.md'
       - '**/*.txt'
-      - '.gitignore'  
+      - '.gitignore'
   pull_request:
     paths-ignore:
-      - 'LICENSE'  
-      - '**/*.md'  
-      - '**/*.txt'  
-      - '.gitignore'  
+      - 'LICENSE'
+      - '**/*.md'
+      - '**/*.txt'
+      - '.gitignore'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compile libiosexec
         run: |
           make all


### PR DESCRIPTION
Github Actions using Node 12 will become obsolete by summer of this year (2023). With this change, the workflow will continue to work after the change has taken full effect. PS: I've taken the time to remove any trailing whitespace too.

For more information, check out [Github's official blog post about the situation and their rationale](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for this change.