### PR TITLE
Add explicit rootless path overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ LIBDIR          ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/lib
 INCLUDEDIR      ?= $(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/include
 
 DEFAULT_INTERPRETER ?= /bin/sh
+ROOTLESS_PREFIX ?= /var/jb
 
 SOVER    := 1
 
@@ -26,7 +27,11 @@ CFLAGS += -g3
 endif
 
 LIBIOSEXEC_PREFIXED_ROOT ?= 0
+ifeq ($(LIBIOSEXEC_PREFIXED_ROOT),1)
+SHEBANG_REDIRECT_PATH    ?= $(ROOTLESS_PREFIX)
+else
 SHEBANG_REDIRECT_PATH    ?= /
+endif
 
 ifeq ($(LIBIOSEXEC_PREFIXED_ROOT),1)
 SRC += $(PWD_SRC)
@@ -34,17 +39,59 @@ else
 SRC += $(WRAP_SRC)
 endif
 
-CFLAGS += -D_PW_NAME_LEN=MAXLOGNAME -DLIBIOSEXEC_INTERNAL -DLIBIOSEXEC_PREFIXED_ROOT=$(LIBIOSEXEC_PREFIXED_ROOT) -DDEFAULT_INTERPRETER='"$(DEFAULT_INTERPRETER)"'
+CFLAGS += -I. -D_PW_NAME_LEN=MAXLOGNAME -DLIBIOSEXEC_INTERNAL -DLIBIOSEXEC_PREFIXED_ROOT=$(LIBIOSEXEC_PREFIXED_ROOT) -DDEFAULT_INTERPRETER='"$(DEFAULT_INTERPRETER)"'
 
 DEFAULT_PATH ?= /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games
+STD_PATH ?= /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ifeq ($(LIBIOSEXEC_PREFIXED_ROOT),1)
+ROOTLESS_BSHELL ?= $(SHEBANG_REDIRECT_PATH)/bin/sh
+ROOTLESS_CSHELL ?= $(SHEBANG_REDIRECT_PATH)/bin/csh
+ROOTLESS_KSHELL ?= $(SHEBANG_REDIRECT_PATH)/bin/ksh
+ROOTLESS_SHELLS ?= $(SHEBANG_REDIRECT_PATH)/etc/shells
+ROOTLESS_PASSWD ?= $(SHEBANG_REDIRECT_PATH)/etc/passwd
+ROOTLESS_MASTERPASSWD ?= $(SHEBANG_REDIRECT_PATH)/etc/master.passwd
+ROOTLESS_GROUP ?= $(SHEBANG_REDIRECT_PATH)/etc/group
+ROOTLESS_MP_DB ?= $(SHEBANG_REDIRECT_PATH)/etc/pwd.db
+ROOTLESS_SMP_DB ?= $(SHEBANG_REDIRECT_PATH)/etc/spwd.db
+REDIRECTED_DEFAULT_PATH := $(shell printf "%s\n" "$(DEFAULT_PATH)" | tr ':' '\n' | sed 'p; s|^|$(SHEBANG_REDIRECT_PATH)|' | tr '\n' ':' | sed 's|:$$||')
+REDIRECTED_STD_PATH := $(shell printf "%s\n" "$(STD_PATH)" | tr ':' '\n' | sed 'p; s|^|$(SHEBANG_REDIRECT_PATH)|' | tr '\n' ':' | sed 's|:$$||')
+else
+ROOTLESS_BSHELL ?= /bin/sh
+ROOTLESS_CSHELL ?= /bin/csh
+ROOTLESS_KSHELL ?= /bin/ksh
+ROOTLESS_SHELLS ?= /etc/shells
+ROOTLESS_PASSWD ?= /etc/passwd
+ROOTLESS_MASTERPASSWD ?= /etc/master.passwd
+ROOTLESS_GROUP ?= /etc/group
+ROOTLESS_MP_DB ?= /etc/pwd.db
+ROOTLESS_SMP_DB ?= /etc/spwd.db
+REDIRECTED_DEFAULT_PATH := $(DEFAULT_PATH)
+REDIRECTED_STD_PATH := $(STD_PATH)
+endif
 
 all: libiosexec.$(SOVER).dylib libiosexec.a
 
-%.o: %.c libiosexec_private.h
+%.o: %.c libiosexec_private.h paths.h
 	$(CC) -c $(CFLAGS) -fvisibility=hidden $<
 
 libiosexec_private.h: libiosexec_private.h.in
-	sed -e "s|@DEFAULT_PATH@|$(shell printf "%s\n" "$(DEFAULT_PATH)" | tr ':' '\n' | sed "p; s|^|$(SHEBANG_REDIRECT_PATH)|" | tr '\n' ':' | sed 's|:$$|\n|')|" -e "s|@SHEBANG_REDIRECT_PATH@|$(SHEBANG_REDIRECT_PATH)|" $^ > $@
+	sed -e 's|@DEFAULT_PATH@|$(REDIRECTED_DEFAULT_PATH)|' -e "s|@SHEBANG_REDIRECT_PATH@|$(SHEBANG_REDIRECT_PATH)|" $^ > $@
+
+paths.h: paths.h.in
+	sed \
+		-e 's|@LIBIOSEXEC_BSHELL@|$(ROOTLESS_BSHELL)|' \
+		-e 's|@LIBIOSEXEC_CSHELL@|$(ROOTLESS_CSHELL)|' \
+		-e 's|@LIBIOSEXEC_KSHELL@|$(ROOTLESS_KSHELL)|' \
+		-e 's|@LIBIOSEXEC_SHELLS@|$(ROOTLESS_SHELLS)|' \
+		-e 's|@LIBIOSEXEC_DEFPATH@|$(REDIRECTED_DEFAULT_PATH)|' \
+		-e 's|@LIBIOSEXEC_STDPATH@|$(REDIRECTED_STD_PATH)|' \
+		-e 's|@LIBIOSEXEC_PASSWD@|$(ROOTLESS_PASSWD)|' \
+		-e 's|@LIBIOSEXEC_MASTERPASSWD@|$(ROOTLESS_MASTERPASSWD)|' \
+		-e 's|@LIBIOSEXEC_GROUP@|$(ROOTLESS_GROUP)|' \
+		-e 's|@LIBIOSEXEC_MP_DB@|$(ROOTLESS_MP_DB)|' \
+		-e 's|@LIBIOSEXEC_SMP_DB@|$(ROOTLESS_SMP_DB)|' \
+		$^ > $@
 
 libiosexec.$(SOVER).dylib: $(SRC:%.c=%.o)
 ifeq ($(shell uname -s), Linux)
@@ -68,6 +115,17 @@ TEST_progs := tests/t_ie_execve \
 	tests/t_ie_posix_spawn \
 	tests/t_ie_posix_spawnp \
 	tests/t_ie_system
+
+REGRESS_BUILD_VARS := LIBIOSEXEC_PREFIXED_ROOT=1 SHEBANG_REDIRECT_PATH="$(PWD)/tests/rootless"
+
+REGRESS_PROGS := tests/t_ie_idlookup \
+	tests/t_ie_getusershell \
+	tests/t_ie_shadowlookup \
+	tests/t_ie_exec_errno \
+	tests/t_ie_spawn_errno
+
+REGRESS_ROOTLESS := $(PWD)/tests/rootless
+REGRESS_PATH := $(PWD)/tests/scripts:$(PWD)/tests/rootless/usr/bin:$(PWD)/tests/rootless/bin:$(PATH)
 
 TEST_scripts := tests/scripts/empty.sh \
 	tests/scripts/normal.sh \
@@ -94,6 +152,20 @@ check: $(TEST_progs)
 	done; \
 	exit $$success
 
+regress:
+	$(MAKE) $(REGRESS_BUILD_VARS) $(REGRESS_PROGS) tests/t_ie_execvp tests/t_ie_posix_spawnp
+	cp tests/scripts/normal.sh tests/scripts/nonexec.sh
+	chmod 0644 tests/scripts/nonexec.sh
+	./tests/t_ie_idlookup
+	./tests/t_ie_getusershell
+	./tests/t_ie_shadowlookup
+	./tests/t_ie_exec_errno ./tests/scripts/nonexec.sh | grep '^13 '
+	./tests/t_ie_spawn_errno ./tests/scripts/nonexec.sh | grep '^13 '
+	PATH="$(REGRESS_PATH)" ./tests/t_ie_execvp $(PWD)/tests/scripts/normal.sh
+	PATH="$(REGRESS_PATH)" ./tests/t_ie_posix_spawnp $(PWD)/tests/scripts/normal.sh
+	PATH="$(REGRESS_PATH)" ./tests/t_ie_execvp $(PWD)/tests/scripts/noshebang.sh
+	PATH="$(REGRESS_PATH)" ./tests/t_ie_posix_spawnp $(PWD)/tests/scripts/noshebang.sh
+
 install: all
 	$(INSTALL) -Dm644 libiosexec.$(SOVER).dylib $(DESTDIR)$(LIBDIR)/libiosexec.$(SOVER).dylib
 	$(LN) -sf libiosexec.$(SOVER).dylib $(DESTDIR)$(LIBDIR)/libiosexec.dylib
@@ -101,6 +173,6 @@ install: all
 	$(INSTALL) -Dm644 libiosexec.h $(DESTDIR)$(INCLUDEDIR)/libiosexec.h
 
 clean:
-	rm -rf libiosexec.$(SOVER).dylib libiosexec.a *.o tests/test tests/*.dSYM *.dSYM libiosexec_private.h $(TEST_progs)
+	rm -rf libiosexec.$(SOVER).dylib libiosexec.a *.o tests/test tests/*.dSYM *.dSYM libiosexec_private.h paths.h $(TEST_progs) $(REGRESS_PROGS) tests/scripts/nonexec.sh
 
-.PHONY: all clean install
+.PHONY: all clean install check regress

--- a/execv.c
+++ b/execv.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <sys/uio.h>
 #include <stdbool.h>
+#include <paths.h>
 
 #include "utils.h"
 #include "libiosexec.h"
@@ -21,21 +22,16 @@
 extern char** environ;
 
 int ie_execve(const char* path, char* const argv[], char* const envp[]) {
-    bool bypass_sysexecve = false;
-
-#if LIBIOSEXEC_PREFIXED_ROOT == 1
-    if (is_shell_script(path)) {
-        bypass_sysexecve = true;
-    }
-#endif
-
-    if (!bypass_sysexecve) {
-        execve(path, argv, envp);
-    }
+    execve(path, argv, envp);
 
     int execve_ret = errno;
 
-    if (!bypass_sysexecve && (execve_ret != EPERM && execve_ret != ENOEXEC)) {
+    if (execve_ret != EPERM && execve_ret != ENOEXEC) {
+        return -1;
+    }
+
+    if (!is_shell_script(path)) {
+        errno = execve_ret;
         return -1;
     }
 
@@ -81,7 +77,7 @@ int ie_execvpe(const char *name, char *const *argv, char *const *envp) {
 
 	/* Get the path we're searching. */
 	if (!(path = getenv("PATH")))
-		path = DEFAULT_PATH;
+		path = _PATH_DEFPATH;
 	len = strlen(path) + 1;
 	cur = alloca(len);
 	if (cur == NULL) {
@@ -142,7 +138,7 @@ retry:		(void)ie_execve(bp, argv, envp);
 			memp[0] = "sh";
 			memp[1] = bp;
 			bcopy(argv + 1, memp + 2, cnt * sizeof(char *));
-			(void)ie_execve(DEFAULT_INTERPRETER, memp, envp);
+			(void)ie_execve(_PATH_BSHELL, memp, envp);
 			goto done;
 		case ENOMEM:
 			goto done;

--- a/getusershell.c
+++ b/getusershell.c
@@ -1,4 +1,25 @@
-/*	$OpenBSD: getusershell.c,v 1.18 2019/12/10 02:35:16 millert Exp $ */
+/*
+ * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_LICENSE_HEADER_END@
+ */
 /*
  * Copyright (c) 1985, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -11,7 +32,11 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the University nor the names of its contributors
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -29,47 +54,29 @@
  */
 
 #include <paths.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
-#include <sys/errno.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
 
 #include "libiosexec.h"
 #include "libiosexec_private.h"
-
-#ifdef _PATH_BSHELL
-#undef _PATH_BSHELL
-#endif
-
-#ifdef _PATH_CSHELL
-#undef _PATH_CSHELL
-#endif
-
-#ifdef _PATH_KSHELL
-#undef _PATH_KSHELL
-#endif
-
-#ifdef _PATH_SHELLS
-#undef _PATH_SHELLS
-#endif
-
-#define _PATH_BSHELL SHEBANG_REDIRECT_PATH "/usr/bin/sh"
-#define _PATH_CSHELL SHEBANG_REDIRECT_PATH "/usr/bin/csh"
-#define _PATH_KSHELL SHEBANG_REDIRECT_PATH "/usr/bin/ksh"
-
-#define _PATH_SHELLS SHEBANG_REDIRECT_PATH "/etc/shells"
 
 /*
  * Local shells should NOT be added here.  They should be added in
  * /etc/shells.
  */
 
-static char *okshells[] = { _PATH_BSHELL, _PATH_CSHELL, _PATH_KSHELL, NULL };
-static char **curshell, **shells;
+static const char *const okshells[] = { _PATH_BSHELL, _PATH_CSHELL, NULL };
+static char **curshell, **shells, *strings;
 static char **initshells(void);
-static void *reallocarray(void *optr, size_t nmemb, size_t size);
 
 /*
  * Get a list of shells from _PATH_SHELLS, if it exists.
@@ -90,14 +97,12 @@ ie_getusershell(void)
 void
 ie_endusershell(void)
 {
-	char **s;
-
-	if ((s = shells))
-		while (*s)
-			free(*s++);
-	free(shells);
+	if (shells != NULL)
+		free(shells);
 	shells = NULL;
-
+	if (strings != NULL)
+		free(strings);
+	strings = NULL;
 	curshell = NULL;
 }
 
@@ -111,72 +116,53 @@ ie_setusershell(void)
 static char **
 initshells(void)
 {
-	size_t nshells, nalloc, linesize;
-	char *line;
+	char **sp, *cp;
 	FILE *fp;
+	struct stat statb;
+#ifdef __APPLE__
+	locale_t loc = uselocale(NULL);
+#endif
 
 	free(shells);
 	shells = NULL;
-
-	if ((fp = fopen(_PATH_SHELLS, "re")) == NULL)
-		return (okshells);
-
-	line = NULL;
-	nalloc = 10; // just an initial guess
-	nshells = 0;
-	shells = reallocarray(NULL, nalloc, sizeof (char *));
-	if (shells == NULL)
-		goto fail;
-	linesize = 0;
-	while (getline(&line, &linesize, fp) != -1) {
-		if (*line != '/')
-			continue;
-		line[strcspn(line, "#\n")] = '\0';
-		if (!(shells[nshells] = strdup(line)))
-			goto fail;
-
-		if (nshells + 1 == nalloc) {
-			char **new = reallocarray(shells, nalloc * 2, sizeof(char *));
-			if (!new)
-				goto fail;
-			shells = new;
-			nalloc *= 2;
-		}
-		nshells++;
+	if (strings != NULL)
+		free(strings);
+	strings = NULL;
+	if ((fp = fopen(_PATH_SHELLS, "r")) == NULL)
+		return (char **)okshells;
+	if (fstat(fileno(fp), &statb) == -1) {
+		(void)fclose(fp);
+		return (char **)okshells;
 	}
-	free(line);
-	shells[nshells] = NULL;
+	if ((strings = malloc((u_int)statb.st_size)) == NULL) {
+		(void)fclose(fp);
+		return (char **)okshells;
+	}
+	shells = calloc((unsigned)statb.st_size / 3, sizeof(char *));
+	if (shells == NULL) {
+		(void)fclose(fp);
+		free(strings);
+		strings = NULL;
+		return (char **)okshells;
+	}
+
+	sp = shells;
+	cp = strings;
+	while (fgets(cp, MAXPATHLEN + 1, fp) != NULL) {
+		while (*cp != '#' && *cp != '/' && *cp != '\0')
+			cp++;
+		if (*cp == '#' || *cp == '\0')
+			continue;
+		*sp++ = cp;
+#ifdef __APPLE__
+		while (!isspace_l(*cp, loc) && *cp != '#' && *cp != '\0')
+#else
+		while (!isspace((unsigned char)*cp) && *cp != '#' && *cp != '\0')
+#endif
+			cp++;
+		*cp++ = '\0';
+	}
+	*sp = NULL;
 	(void)fclose(fp);
 	return (shells);
-
-fail:
-	free(line);
-	while (nshells)
-		free(shells[nshells--]);
-	free(shells);
-	shells = NULL;
-	(void)fclose(fp);
-	return (okshells);
-}
-
-
-// The following taken from OpenBSD reallocarray.c
-
-/*
- * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
- * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
- */
-#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
-
-static void *
-reallocarray(void *optr, size_t nmemb, size_t size)
-{
-	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
-	    nmemb > 0 && SIZE_MAX / nmemb < size) {
-		errno = ENOMEM;
-		return NULL;
-	}
-	if (size == 0 || nmemb == 0)
-	    return NULL;
-	return realloc(optr, size * nmemb);
 }

--- a/libiosexec_private.h.in
+++ b/libiosexec_private.h.in
@@ -1,9 +1,9 @@
 #include "libiosexec.h"
+#include "paths.h"
 
 IOSEXEC_HIDDEN char** get_new_argv(const char* path, char* const argv[]);
 IOSEXEC_HIDDEN void free_new_argv(char** argv);
 // PATH_MAX for Darwin
 #define PATH_MAX 1024
 
-#define DEFAULT_PATH "@DEFAULT_PATH@"
 #define SHEBANG_REDIRECT_PATH "@SHEBANG_REDIRECT_PATH@"

--- a/paths.h.in
+++ b/paths.h.in
@@ -1,0 +1,61 @@
+#ifndef LIBIOSEXEC_PATHS_H
+#define LIBIOSEXEC_PATHS_H
+
+#include <sys/paths.h>
+
+#ifdef _PATH_BSHELL
+#undef _PATH_BSHELL
+#endif
+#define _PATH_BSHELL "@LIBIOSEXEC_BSHELL@"
+
+#ifdef _PATH_CSHELL
+#undef _PATH_CSHELL
+#endif
+#define _PATH_CSHELL "@LIBIOSEXEC_CSHELL@"
+
+#ifdef _PATH_KSHELL
+#undef _PATH_KSHELL
+#endif
+#define _PATH_KSHELL "@LIBIOSEXEC_KSHELL@"
+
+#ifdef _PATH_SHELLS
+#undef _PATH_SHELLS
+#endif
+#define _PATH_SHELLS "@LIBIOSEXEC_SHELLS@"
+
+#ifdef _PATH_DEFPATH
+#undef _PATH_DEFPATH
+#endif
+#define _PATH_DEFPATH "@LIBIOSEXEC_DEFPATH@"
+
+#ifdef _PATH_STDPATH
+#undef _PATH_STDPATH
+#endif
+#define _PATH_STDPATH "@LIBIOSEXEC_STDPATH@"
+
+#ifdef _PATH_PASSWD
+#undef _PATH_PASSWD
+#endif
+#define _PATH_PASSWD "@LIBIOSEXEC_PASSWD@"
+
+#ifdef _PATH_MASTERPASSWD
+#undef _PATH_MASTERPASSWD
+#endif
+#define _PATH_MASTERPASSWD "@LIBIOSEXEC_MASTERPASSWD@"
+
+#ifdef _PATH_GROUP
+#undef _PATH_GROUP
+#endif
+#define _PATH_GROUP "@LIBIOSEXEC_GROUP@"
+
+#ifdef _PATH_MP_DB
+#undef _PATH_MP_DB
+#endif
+#define _PATH_MP_DB "@LIBIOSEXEC_MP_DB@"
+
+#ifdef _PATH_SMP_DB
+#undef _PATH_SMP_DB
+#endif
+#define _PATH_SMP_DB "@LIBIOSEXEC_SMP_DB@"
+
+#endif

--- a/posix_spawn.c
+++ b/posix_spawn.c
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <stdbool.h>
+#include <paths.h>
 
 #include "utils.h"
 #include "libiosexec.h"
@@ -14,21 +15,15 @@ int ie_posix_spawn(pid_t *pid, const char *path,
                        const posix_spawnattr_t *attrp,
                        char *const argv[],
                        char *const envp[]) {
-   bool bypass_sysposix_spawn = false;
    int err;
+   err = posix_spawn(pid, path, file_actions, attrp, argv, envp);
 
-#if LIBIOSEXEC_PREFIXED_ROOT == 1
-   if (is_shell_script(path)) {
-       bypass_sysposix_spawn = true;
-   }
-#endif
-
-   if (!bypass_sysposix_spawn)
-       err = posix_spawn(pid, path, file_actions, attrp, argv, envp);
-
-   if (!bypass_sysposix_spawn && (err != EPERM && err != ENOEXEC)) {
+   if (err != EPERM && err != ENOEXEC) {
        return err;
    }
+
+   if (!is_shell_script(path))
+       return err;
 
    char** new_args = get_new_argv(path, argv);
    if (new_args == NULL) {
@@ -62,7 +57,7 @@ ie_posix_spawnp(pid_t *pid, const char *file,
 	char path_buf[PATH_MAX];
 
 	if ((env_path = getenv("PATH")) == NULL)
-		env_path = DEFAULT_PATH;
+		env_path = _PATH_DEFPATH;
 
 	/* If it's an absolute or relative path name, it's easy. */
 	if (strchr(file, '/')) {
@@ -128,7 +123,7 @@ retry:		err = ie_posix_spawn(pid, bp, file_actions, attrp, argv, envp);
 			memp[0] = "sh";
 			memp[1] = bp;
 			bcopy(argv + 1, memp + 2, cnt * sizeof(char *));
-			err = ie_posix_spawn(pid, "/bin/sh", file_actions, attrp, memp, envp);
+			err = ie_posix_spawn(pid, _PATH_BSHELL, file_actions, attrp, memp, envp);
 			goto done;
 		default:
 			/*

--- a/tests/rootless/etc/shells
+++ b/tests/rootless/etc/shells
@@ -1,0 +1,4 @@
+   /var/jb/bin/sh
+# comment
+/var/jb/bin/csh
+/var/jb/bin/zsh # keep trailing comment

--- a/tests/t_ie_getusershell.c
+++ b/tests/t_ie_getusershell.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <libiosexec.h>
+
+int
+main(void)
+{
+	char *shell;
+
+	ie_setusershell();
+
+	shell = ie_getusershell();
+	if (shell == NULL || strcmp(shell, "/var/jb/bin/sh") != 0)
+		return 1;
+
+	shell = ie_getusershell();
+	if (shell == NULL || strcmp(shell, "/var/jb/bin/csh") != 0)
+		return 2;
+
+	shell = ie_getusershell();
+	if (shell == NULL || strcmp(shell, "/var/jb/bin/zsh") != 0)
+		return 3;
+
+	if (ie_getusershell() != NULL)
+		return 4;
+
+	ie_endusershell();
+	return 0;
+}


### PR DESCRIPTION
## Summary
- generate a local paths.h for prefixed-root builds instead of relying on SDK path macros
- switch getusershell to the Apple/Darwin implementation model while honoring the generated path layer
- use _PATH_* in execvp/spawnp search fallbacks and add rootless /etc/shells regression coverage

## Testing
- make -C /Users/torrekie/proj/libiosexec-remorix-pr clean >/dev/null && make -C /Users/torrekie/proj/libiosexec-remorix-pr LIBIOSEXEC_PREFIXED_ROOT=1 SHEBANG_REDIRECT_PATH=/Users/torrekie/proj/libiosexec-remorix-pr/tests/rootless tests/t_ie_getusershell tests/t_ie_execvp tests/t_ie_posix_spawnp
- /Users/torrekie/proj/libiosexec-remorix-pr/tests/t_ie_getusershell